### PR TITLE
添加重定向到登录页面功能

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -42,3 +42,9 @@ superuser = "17120238"
 prefix = "/api/semester"
 read = { everybody = true }
 write = { everybody = true }
+
+[['dev.cloud.shuosc.com'.urls]]
+prefix = "/api/xxx"
+redirect_location = "/ping"
+read = { everybody = true } # 对每个人：可读
+write = { superuser = true } # 对管理员：可写

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -48,10 +48,10 @@ pub async fn check(request: HttpRequest) -> impl Responder {
             _ => return HttpResponse::UnprocessableEntity(),
         }
     };
-    let passed = CONFIG
+    let (passed, redirect_location) = CONFIG
         .get(&host)
         .map(|it| it.check(username.as_ref(), path, query, write))
-        .unwrap_or(false);
+        .unwrap_or((false, None));
     if passed {
         info!(
             "Allow {} to {} {}{}",
@@ -69,6 +69,12 @@ pub async fn check(request: HttpRequest) -> impl Responder {
             host,
             path
         );
-        HttpResponse::Unauthorized()
+        if let Some(location) = redirect_location {
+            HttpResponse::SeeOther()
+                .header(actix_web::http::header::LOCATION, location.to_owned())
+                .take()
+        } else {
+            HttpResponse::Unauthorized()
+        }
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -70,6 +70,10 @@ pub async fn check(request: HttpRequest) -> impl Responder {
             path
         );
         if let Some(location) = redirect_location {
+            info!(
+                "Redirecting to {}",
+                location
+            );
             HttpResponse::SeeOther()
                 .header(actix_web::http::header::LOCATION, location.to_owned())
                 .take()


### PR DESCRIPTION
<!--
下面的内容可以使用中文或者英文填写。
-->

<!--
You can fill the following things by using English or Chinese.
-->


### What problem does this PR solve?

Issue Number: close #9 <!-- REMOVE this line if no issue to close -->

Problem Summary: 若用户没有登录，将用户重定向到配置文件中给出的url。

### What is changed and how it works?

What's Changed: 在`URLConfig`中添加了一个`Option<String>`类型的成员`redirect_location`，改写了`Config`的`check`函数，使其返回的是一个`(bool, Option<&String>)`类型的元组，使其可以在返回中附带重定向url。之后如果为通过鉴权，就会检查有没有可用的重定向url，如果有就通过SEE_OTHER设定Location: url重定向。🎉

有关为什么改写的是check函数：这是目前我认为相对高效的写法，因为**目前**如果在未通过鉴权之后再去查询`redirect_location`，就需要重新遍历`Config`的`urls`。这样是有悖于HPermission的初衷的，对吧？🥺️